### PR TITLE
agent: delete backups

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -34,7 +34,7 @@ func lookupGroup(groupName string) (int, error) {
 	return int(gid), nil
 }
 
-func removeOld(destDir string) {
+func removeOld(destDir string, dryRun bool) {
 	files, err := ioutil.ReadDir(destDir)
 	if err != nil {
 		panic(err)
@@ -44,11 +44,15 @@ func removeOld(destDir string) {
 			continue
 		}
 		filePath := filepath.Join(destDir, file.Name())
-		log.Printf("deleting %s", filePath)
-		err := os.Remove(filePath)
-		if err != nil {
-			log.Printf("ERROR: %v", err)
-			continue
+		if dryRun {
+			log.Printf("deleting %s (dryrun)", filePath)
+		} else {
+			log.Printf("deleting %s", filePath)
+			err := os.Remove(filePath)
+			if err != nil {
+				log.Printf("ERROR: %v", err)
+				continue
+			}
 		}
 	}
 }
@@ -95,7 +99,7 @@ func backup(ctx context.Context, pubKey *stream.PublicKey, cfg *config) error {
 	pathsToCheck := existingSC.Paths()
 
 	if sc.instance == 0 {
-		removeOld(destDir)
+		removeOld(destDir, cfg.DryRun)
 	}
 
 	log.Printf("----------  RUNNING LEVEL %d (%v) -----------", sc.instance, sc.timeStamp)

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type RestoreConfig struct {
 }
 
 type config struct {
+	DryRun     bool
 	Profile    bool
 	BackupPath string
 	Backup     BackupConfig

--- a/multus-agent/agent.go
+++ b/multus-agent/agent.go
@@ -124,9 +124,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "ERROR: Wait: %v\n", err)
 		}
 	}
-	cancel()
-
-	err = cleanup(cfg.StoragePath, cfg.MaxSize)
+	err = cleanup(ctx, cfg.StoragePath, cfg.MaxSize)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup: %v\n", err)
 	}

--- a/multus-agent/agent.go
+++ b/multus-agent/agent.go
@@ -124,7 +124,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "ERROR: Wait: %v\n", err)
 		}
 	}
-	err = cleanup(ctx, cfg.StoragePath, cfg.MaxSize)
+	err = cleanup(ctx, cfg.StoragePath, cfg.MaxSize, cfg.DryRun)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup: %v\n", err)
 	}

--- a/multus-agent/cleanup.go
+++ b/multus-agent/cleanup.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
-	"syscall"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -15,11 +17,6 @@ var (
 	fileRexp = regexp.MustCompile(`\.gz\.enc$`)
 	hashRexp = regexp.MustCompile(`[[:xdigit:]]{64}`)
 )
-
-type Cleanup struct {
-	Timestamp time.Time
-	Files     map[string]os.FileInfo
-}
 
 type File struct {
 	Path      string
@@ -41,40 +38,78 @@ func (f Files) Swap(a, b int) {
 	f[a], f[b] = f[b], f[a]
 }
 
-func cleanup(storagePath string, maxSize int64) error {
+func genTimestamp(name string) (time.Time, error) {
+	if len(name) < 12 {
+		return time.Time{}, fmt.Errorf("invalid filename")
+	}
+
+	year, err := strconv.ParseInt(string(name[0:4]), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	month, err := strconv.ParseInt(string(name[4:6]), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	day, err := strconv.ParseInt(string(name[6:8]), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	hour, err := strconv.ParseInt(string(name[8:10]), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	min, err := strconv.ParseInt(string(name[10:12]), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Date(int(year), time.Month(month), int(day), int(hour), int(min), 0, 0, time.Local), nil
+}
+
+func cleanup(ctx context.Context, storagePath string, maxSize int64) error {
 	var totalSize int64
-	now := time.Now()
 	var files Files
 	err := filepath.Walk(storagePath, func(srcPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		st, err := os.Stat(srcPath)
 		if err != nil {
 			return err
 		}
 		if !st.Mode().IsDir() && !st.Mode().IsRegular() {
-			return err
+			log.Printf("%q: unknown file -- skipping", srcPath)
+			return nil
 		}
 		if st.Mode().IsDir() {
 			return nil
 		}
-		sysStat, ok := st.Sys().(*syscall.Stat_t)
-		if !ok {
-			return fmt.Errorf("stat returned type %T", st.Sys())
+		totalSize += st.Size()
+		fileName := filepath.Base(srcPath)
+		if !strings.HasSuffix(fileName, ".gz.enc") {
+			if fileName != "sig.cache" {
+				log.Printf("%q: unknown file -- skipping", srcPath)
+			}
+			return nil
+		}
+		if len(fileName) < 21 {
+			log.Printf("%q: invalid file -- skipping", srcPath)
+			return nil
+		}
+
+		timestamp, err := genTimestamp(fileName)
+		if err != nil {
+			log.Printf("%q: genTimestamp: %v", srcPath, err)
+			return nil
 		}
 		file := File{
 			Path:      srcPath,
 			Size:      st.Size(),
-			Timestamp: time.Unix(sysStat.Ctim.Sec, sysStat.Ctim.Nsec),
-		}
-		totalSize += file.Size
-		fileName := filepath.Base(srcPath)
-		if !fileRexp.MatchString(fileName) {
-			if fileName != "sig.cache" {
-				log.Printf("%q: unknown file", srcPath)
-			}
-			return nil
+			Timestamp: timestamp,
 		}
 		files = append(files, file)
 		return nil
@@ -89,36 +124,29 @@ func cleanup(storagePath string, maxSize int64) error {
 	log.Printf("doing cleanup...")
 
 	sort.Sort(files)
-	hashes := make(map[string]time.Duration)
+	log.Printf("%+v", files)
+
+	deletedSize := int64(0)
+	curTime := files[0].Timestamp
 	for _, file := range files {
-		fileHash := hashRexp.FindString(filepath.Base(file.Path))
-		fileAge := now.Sub(file.Timestamp)
-
-		if age, exists := hashes[fileHash]; exists {
-			if fileAge > age {
-				hashes[fileHash] = fileAge
-			}
-			continue
-		}
-		hashes[fileHash] = fileAge
-	}
-
-	for hash, age := range hashes {
-		var size int64
-		for _, file := range files {
-			fileHash := hashRexp.FindString(filepath.Base(file.Path))
-			if fileHash != hash {
-				continue
-			}
-			size += file.Size
-			totalSize -= file.Size
-			log.Printf("%q: delete", file.Path)
-		}
-		log.Printf("%s: deleted %d bytes, age: %v", hash, size, age)
-		if totalSize <= maxSize {
+		if ctx.Err() != nil {
 			break
 		}
+		if curTime != file.Timestamp {
+			if totalSize <= maxSize {
+				break
+			}
+			curTime = file.Timestamp
+		}
+		log.Printf("deleting %q (%d)", file.Path, file.Size)
+		if err = os.Remove(file.Path); err != nil {
+			log.Printf("ERROR: Remove: %s: %v", file.Path, err)
+			continue
+		}
+		totalSize -= file.Size
+		deletedSize += file.Size
 	}
+	log.Printf("deleted %d bytes", deletedSize)
 
 	return nil
 }

--- a/multus-agent/cleanup.go
+++ b/multus-agent/cleanup.go
@@ -67,7 +67,7 @@ func genTimestamp(name string) (time.Time, error) {
 	return time.Date(int(year), time.Month(month), int(day), int(hour), int(min), 0, 0, time.Local), nil
 }
 
-func cleanup(ctx context.Context, storagePath string, maxSize int64) error {
+func cleanup(ctx context.Context, storagePath string, maxSize int64, dryRun bool) error {
 	var totalSize int64
 	var files Files
 	err := filepath.Walk(storagePath, func(srcPath string, info os.FileInfo, err error) error {
@@ -138,10 +138,14 @@ func cleanup(ctx context.Context, storagePath string, maxSize int64) error {
 			}
 			curTime = file.Timestamp
 		}
-		log.Printf("deleting %q (%d)", file.Path, file.Size)
-		if err = os.Remove(file.Path); err != nil {
-			log.Printf("ERROR: Remove: %s: %v", file.Path, err)
-			continue
+		if dryRun {
+			log.Printf("deleting %q (%d) (dryrun)", file.Path, file.Size)
+		} else {
+			log.Printf("deleting %q (%d)", file.Path, file.Size)
+			if err = os.Remove(file.Path); err != nil {
+				log.Printf("ERROR: Remove: %s: %v", file.Path, err)
+				continue
+			}
 		}
 		totalSize -= file.Size
 		deletedSize += file.Size

--- a/multus-agent/config.go
+++ b/multus-agent/config.go
@@ -18,6 +18,7 @@ type Host struct {
 }
 
 type config struct {
+	DryRun      bool
 	StoragePath string
 	BWLimit     string
 	MaxSize     int64


### PR DESCRIPTION
The agent will delete groups of backups, sorted by oldest first,
until the total storage size is less than the max set size.

Closes #7 